### PR TITLE
Set neutral language to `English (World)`

### DIFF
--- a/ZeldaFullEditor/Properties/AssemblyInfo.cs
+++ b/ZeldaFullEditor/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Resources;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -34,3 +35,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0")]
 [assembly: AssemblyFileVersion("1.0")]
+[assembly: NeutralResourcesLanguage("en-001")]
+


### PR DESCRIPTION
## Features
A neutral language lets the program know which locale the UI should use if none is specified by the user. This also opens the door for localizing other resources, which require a default locale to be set.

## Notes
My decision to use `English (World)` over, say `English (United States)` is simply because this project is being handled by international English speakers.
