### PR TITLE
Rename `Sorting` to `RoomObjectType`

### DIFF
--- a/ZeldaFullEditor/Gui/Form1.cs
+++ b/ZeldaFullEditor/Gui/Form1.cs
@@ -1197,7 +1197,7 @@ namespace ZeldaFullEditor
             //objectViewer1.BeginUpdate();
             objectViewer1.items.Clear();
             //Sorting sort;
-            Sorting sortsizing = Sorting.All;
+            RoomObjectType sortsizing = RoomObjectType.All;
             string searchText = searchTextbox.Text.ToLower();
             //listView1
             objectViewer1.items.AddRange(listoftilesobjects

--- a/ZeldaFullEditor/Rooms/Object_Draw/Subtype1_Draw.cs
+++ b/ZeldaFullEditor/Rooms/Object_Draw/Subtype1_Draw.cs
@@ -15,7 +15,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Ceiling ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -41,7 +41,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Top Wall Horiz. ↔";
-            sort = Sorting.Horizontal | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Wall;
 
         }
 
@@ -71,7 +71,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Bottom Wall Horiz. ↔";
-            sort = Sorting.Horizontal | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -100,7 +100,7 @@ namespace ZeldaFullEditor
             addTiles(8, pos);
             allBgs = true;
             name = "Top Wall Horiz. (Lower) ↔";
-            sort = Sorting.Horizontal | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -125,7 +125,7 @@ namespace ZeldaFullEditor
             addTiles(8, pos);
             allBgs = true;
             name = "Bottom Wall Horiz. (Lower) ↔";
-            sort = Sorting.Horizontal | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -149,7 +149,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Top Wall Column ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -173,7 +173,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Bottom Wall Column ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -197,7 +197,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Top Wall Pit ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -219,7 +219,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Bottom Wall Pit ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -241,7 +241,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -259,7 +259,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -277,7 +277,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -295,7 +295,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -314,7 +314,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -332,7 +332,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -350,7 +350,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -368,7 +368,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -386,7 +386,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -404,7 +404,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -422,7 +422,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -440,7 +440,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◢ ";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -458,7 +458,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -477,7 +477,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -496,7 +496,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -515,7 +515,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -534,7 +534,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -553,7 +553,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -572,7 +572,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -591,7 +591,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -610,7 +610,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -628,7 +628,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -646,7 +646,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -664,7 +664,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(5, pos);
             name = "Diagonal Wall ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -683,7 +683,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(9, pos);
             name = "Mini Stairs ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -716,7 +716,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(3, pos);
             name = "Horizontal Rail ↔";
-            sort = Sorting.Horizontal | Sorting.Dungeons;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -741,7 +741,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(3, pos);
             name = "Pit Top Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -766,7 +766,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(3, pos);
             name = "Pit Top Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -792,7 +792,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Pit Top Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -816,7 +816,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Pit Top Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -842,7 +842,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Pit Top Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -868,7 +868,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Pit Bottom Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -894,7 +894,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Pit Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -920,7 +920,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Pit Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -946,7 +946,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Pit Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -972,7 +972,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             name = "Pit Edge ↔";
             
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -998,7 +998,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             name = "Pit Edge ↔";
             
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1024,7 +1024,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             name = "Pit Edge ↔";
             
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1049,7 +1049,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(6, pos);
             name = "Rail Wall ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1081,7 +1081,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(6, pos);
             name = "Rail Wall ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1140,7 +1140,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Carpet Floor ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1170,7 +1170,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Carpet Contour ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1206,7 +1206,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Curtain ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1236,7 +1236,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Side Curtain? ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1267,7 +1267,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(6, pos);
             name = "Statue ↔";
-            sort = Sorting.Horizontal | Sorting.Dungeons;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -1303,7 +1303,7 @@ namespace ZeldaFullEditor
                 draw_tile(tiles[2], ((s * 6)) * 8, (2) * 8); draw_tile(tiles[6], (1 + (s * 6)) * 8, (2) * 8);
                 draw_tile(tiles[3], ((s * 6)) * 8, (3) * 8); draw_tile(tiles[7], (1 + (s * 6)) * 8, (3) * 8);
             }
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
     }
 
@@ -1333,7 +1333,7 @@ namespace ZeldaFullEditor
                     }
                 }
             }
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
     }
 
@@ -1362,7 +1362,7 @@ namespace ZeldaFullEditor
                     }
                 }
             }
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
     }
 
@@ -1387,7 +1387,7 @@ namespace ZeldaFullEditor
                 draw_tile(tiles[0], ((s * 4)) * 8, (6) * 8); draw_tile(tiles[2], (1 + (s * 4)) * 8, (6) * 8);
                 draw_tile(tiles[1], ((s * 4)) * 8, (7) * 8); draw_tile(tiles[3], (1 + (s * 4)) * 8, (7) * 8);
             }
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
     }
 
@@ -1399,7 +1399,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Floor Torch ↔";
-            sort = Sorting.Horizontal | Sorting.Dungeons;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -1425,7 +1425,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Top Wall Column ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1453,7 +1453,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1479,7 +1479,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1505,7 +1505,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1531,7 +1531,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1557,7 +1557,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1583,7 +1583,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1610,7 +1610,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1637,7 +1637,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Water Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1660,7 +1660,7 @@ namespace ZeldaFullEditor
         public object_47(short id, byte x, byte y, byte size, byte layer) : base(id, x, y, size, layer)
         {
             name = "Unused Waterfall ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1675,7 +1675,7 @@ namespace ZeldaFullEditor
         public object_48(short id, byte x, byte y, byte size, byte layer) : base(id, x, y, size, layer)
         {
             name = "Unused Waterfall ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1734,7 +1734,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Bottom Wall Column ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1759,7 +1759,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(9, pos);
             name = "Bar ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1791,7 +1791,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Shelf ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1825,7 +1825,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Shelf ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1859,7 +1859,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Shelf ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1916,7 +1916,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(18, pos);
             name = "Canon Hole ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -1947,7 +1947,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(18, pos);
             name = "Canon Hole ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -2013,7 +2013,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Wall Torches ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -2035,7 +2035,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Wall Torches ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -2113,7 +2113,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(18, pos);
             name = "Canon Hole ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -2144,7 +2144,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(18, pos);
             name = "Canon Hole ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -2176,7 +2176,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(15, pos);
             name = "Large Horizontal Rail ↔";
-            sort = Sorting.Horizontal | Sorting.Dungeons;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -2208,7 +2208,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Block ↔";
-            sort = Sorting.Horizontal | Sorting.Dungeons;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -2232,7 +2232,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(3, pos);
             name = "Long Horizontal Rail ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -2256,7 +2256,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Ceiling ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
 
         }
         
@@ -2283,7 +2283,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Left Wall Vertic. ↕";
-            sort = Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Vertical | RoomObjectType.Wall;
 
         }
         
@@ -2310,7 +2310,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Right Wall Horiz. ↕";
-            sort = Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -2335,7 +2335,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Left Wall Horiz. (Lower) ↕";
-            sort = Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -2357,7 +2357,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Right Wall Horiz. (Lower) ↕";
-            sort = Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Vertical | RoomObjectType.Wall;
             allBgs = true;
         }
 
@@ -2380,7 +2380,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Left Wall Column ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
 
         }
 
@@ -2403,7 +2403,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Right Wall Column ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
 
         }
 
@@ -2425,7 +2425,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Left Wall Pit ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2446,7 +2446,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Right Wall Pit ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2469,7 +2469,7 @@ namespace ZeldaFullEditor
             addTiles(3, pos);
             
             name = "Vertical Rail ↕";
-            sort = Sorting.Vertical | Sorting.Dungeons;
+            sort = RoomObjectType.Vertical | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -2498,7 +2498,7 @@ namespace ZeldaFullEditor
             addTiles(1, pos);
 
             name = "Left Pit Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2519,7 +2519,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Right Pit Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2541,7 +2541,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(6, pos);
             name = "Rail Wall Left ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2573,7 +2573,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(6, pos);
             name = "Rail Wall Right ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2635,7 +2635,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Carpet Floor ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2665,7 +2665,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Carpet Floor Contour ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2701,7 +2701,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Left Curtain ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2731,7 +2731,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Right Curtain ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2762,7 +2762,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Column ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2787,7 +2787,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Left Wall Decoration ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2818,7 +2818,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Right Wall Decoration ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2848,7 +2848,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Left Wall Top Column ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2878,7 +2878,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Water Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2899,7 +2899,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Water Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2920,7 +2920,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Right Wall Top Column ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -2950,7 +2950,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Water Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3015,7 +3015,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Left Wall Torches ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3046,7 +3046,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Right Wall Torches ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3077,7 +3077,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(12, pos);
             name = "Left Wall Decoration ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3107,7 +3107,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(12, pos);
             name = "Right Wall Decoration ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3137,7 +3137,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(12, pos);
             name = "Left Wall Decoration?? ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3167,7 +3167,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(12, pos);
             name = "Right Wall Decoration?? ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3197,7 +3197,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(18, pos);
             name = "Left Wall Canon Hole ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3215,7 +3215,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(18, pos);
             name = "Right Wall Canon Hole ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3233,7 +3233,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Floor Torch ↕";
-            sort = Sorting.Vertical |Sorting.Dungeons;
+            sort = RoomObjectType.Vertical |RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -3258,7 +3258,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(12, pos);
             name = "Large Vertical Rail ↕";
-            sort = Sorting.Vertical | Sorting.Dungeons;
+            sort = RoomObjectType.Vertical | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -3285,7 +3285,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Block Vertical ↕";
-            sort = Sorting.Vertical | Sorting.Dungeons;
+            sort = RoomObjectType.Vertical | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -3330,7 +3330,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(3, pos);
             name = "Left Vertical Jump Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
 
         }
 
@@ -3352,7 +3352,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(3, pos);
             name = "Right Vertical Jump Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3374,7 +3374,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Left Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3395,7 +3395,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Right Edge ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3440,7 +3440,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Left Wall Vertic. ↕";
-            sort = Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Vertical | RoomObjectType.Wall;
 
         }
 
@@ -3467,7 +3467,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Right Wall Horiz. ↕";
-            sort = Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Vertical | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -3493,7 +3493,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Blue Peg Block ↕";
-            sort = Sorting.Vertical | Sorting.Dungeons;
+            sort = RoomObjectType.Vertical | RoomObjectType.Dungeons;
 
         }
         
@@ -3521,7 +3521,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Orange Peg Block ↕";
-            sort = Sorting.Vertical | Sorting.Dungeons;
+            sort = RoomObjectType.Vertical | RoomObjectType.Dungeons;
 
         }
 
@@ -3549,7 +3549,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Invisible Floor ↕";
-            sort = Sorting.Vertical | Sorting.Dungeons | Sorting.Floors;
+            sort = RoomObjectType.Vertical | RoomObjectType.Dungeons | RoomObjectType.Floors;
         }
 
         public override void Draw()
@@ -3579,7 +3579,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Fake Pot ↕";
-            sort = Sorting.Vertical;
+            sort = RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3602,7 +3602,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Hammer Peg Block ↕";
-            sort = Sorting.Vertical | Sorting.Dungeons;
+            sort = RoomObjectType.Vertical | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -3741,7 +3741,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3767,7 +3767,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3793,7 +3793,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3819,7 +3819,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3845,7 +3845,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(24, pos);
             name = "Hole ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
         //TODO: Take the draw code from disassembly ("HARDCODED")
         public override void Draw()
@@ -3887,7 +3887,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3913,7 +3913,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3939,7 +3939,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3965,7 +3965,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -3991,7 +3991,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◤";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -4017,7 +4017,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◣";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -4043,7 +4043,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◥";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -4069,7 +4069,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Diagonal Ceiling ◢";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -4143,7 +4143,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Bottom Horizontal Jump Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -4164,7 +4164,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(1, pos);
             name = "Bottom Horizontal Jump Edge ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -4186,7 +4186,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Floor? ↔";
-            sort = Sorting.Horizontal | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Floors;
         }
 
         public override void Draw()
@@ -4293,7 +4293,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Top Wall? ↔";
-            sort = Sorting.Horizontal | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -4323,7 +4323,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(8, pos);
             name = "Bottom Wall ↔";
-            sort = Sorting.Horizontal | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Wall;
         }
 
         public override void Draw()
@@ -4354,7 +4354,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Blue Switch Block ↔";
-            sort = Sorting.Horizontal | Sorting.Dungeons;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Dungeons;
         }
         
         public override void Draw()
@@ -4388,7 +4388,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Red Switch Block ↔";
-            sort = Sorting.Horizontal | Sorting.Dungeons;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Dungeons;
         }
 
         public override void Draw()
@@ -4421,7 +4421,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(16, pos);
             name = "Invisible Floor ↔";
-            sort = Sorting.Horizontal | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Floors;
         }
 
         public override void Draw()
@@ -4475,7 +4475,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "fake pots ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -4501,7 +4501,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             addTiles(4, pos);
             name = "Hammer Pegs ↔";
-            sort = Sorting.Horizontal;
+            sort = RoomObjectType.Horizontal;
         }
 
         public override void Draw()
@@ -4556,7 +4556,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Ceiling Large ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
             addTiles(1, pos);
         }
 
@@ -4590,7 +4590,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Chest Contour Floor ↔ ↕";
             addTiles(68, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -4657,7 +4657,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Bg2 Large Overlay ↔ ↕";
             addTiles(1, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
 
         }
 
@@ -4691,7 +4691,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Bg2 Medium Overlay ↔ ↕";
             addTiles(1, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -4721,7 +4721,7 @@ namespace ZeldaFullEditor
 
         public object_C4(short id, byte x, byte y, byte size, byte layer) : base(id, x, y, size, layer)
         {
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             name = "Floor1 ↔ ↕";
         }
 
@@ -4762,7 +4762,7 @@ namespace ZeldaFullEditor
 
         public object_C5(short id, byte x, byte y, byte size, byte layer) : base(id, x, y, size, layer)
         {
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Floor3 ↔ ↕";
             addTiles(8, pos);//??
@@ -4802,7 +4802,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Bg2 Large Overlay ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
         public override void Draw()
@@ -4840,7 +4840,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Floor4 ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -4877,7 +4877,7 @@ namespace ZeldaFullEditor
 
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Water Floor ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             addTiles(8, pos);//??
         }
 
@@ -4917,7 +4917,7 @@ namespace ZeldaFullEditor
 
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Water Floor2 ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             addTiles(8, pos);//??
         }
 
@@ -4956,7 +4956,7 @@ namespace ZeldaFullEditor
 
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Floor5 ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             addTiles(8, pos);//??
         }
 
@@ -5030,7 +5030,7 @@ namespace ZeldaFullEditor
 
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Moving Wall Left ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             addTiles(8, pos);//??
         }
 
@@ -5049,7 +5049,7 @@ namespace ZeldaFullEditor
 
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Moving Wall Left ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Wall;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Wall;
             addTiles(8, pos);//??
         }
 
@@ -5105,7 +5105,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Water Floor3 ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5144,7 +5144,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Floor6 ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5254,7 +5254,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "overlay tile? ↔ ↕";
             addTiles(1, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
 
@@ -5291,7 +5291,7 @@ namespace ZeldaFullEditor
 
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Lava Background? ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             addTiles(8, pos);//??
         }
 
@@ -5330,7 +5330,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Hole?? ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
 
@@ -5367,7 +5367,7 @@ namespace ZeldaFullEditor
 
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Lava Background 2 ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             addTiles(8, pos);//??
         }
 
@@ -5402,7 +5402,7 @@ namespace ZeldaFullEditor
 
         public object_DB(short id, byte x, byte y, byte size, byte layer) : base(id, x, y, size, layer)
         {
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
             name = "Floor2 ↔ ↕";
         }
 
@@ -5446,7 +5446,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Chest Platform? ↔ ↕";
             addTiles(21, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
 
@@ -5545,7 +5545,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Table / Rock ↔ ↕";
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
             addTiles(16, pos);
 
         }
@@ -5604,7 +5604,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Spike Block ↔ ↕";
             addTiles(4, pos);
-            sort = Sorting.Horizontal | Sorting.Vertical;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical;
         }
 
 
@@ -5636,7 +5636,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Spike Floor ↔ ↕";
             addTiles(8, pos);
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5675,7 +5675,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Floor7 ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5713,7 +5713,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Floor9 ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5751,7 +5751,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Rupee Floor ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5789,7 +5789,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Moving Floor Up ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5827,7 +5827,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Moving Floor Down ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5865,7 +5865,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Moving Floor Left ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5903,7 +5903,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Moveing Floor Right ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5942,7 +5942,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Moving Floor? ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 
@@ -5980,7 +5980,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2) + 1] << 8) + ROM.DATA[Constants.subtype1_tiles + ((id & 0xFF) * 2)]);
             name = "Weird Floor? ↔ ↕";
             addTiles(8, pos);//??
-            sort = Sorting.Horizontal | Sorting.Vertical | Sorting.Floors;
+            sort = RoomObjectType.Horizontal | RoomObjectType.Vertical | RoomObjectType.Floors;
         }
 
 

--- a/ZeldaFullEditor/Rooms/Object_Draw/Subtype2_Multiple.cs
+++ b/ZeldaFullEditor/Rooms/Object_Draw/Subtype2_Multiple.cs
@@ -18,242 +18,242 @@ namespace ZeldaFullEditor
             if (oid == 0)
             {
                 setdata("Wall Inner Corner ▛", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid == 1)
             {
                 setdata("Wall Inner Corner ▙", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid == 2)
             {
                 setdata("Wall Inner Corner ▜", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid == 3)
             {
                 setdata("Wall Inner Corner ▟", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid == 4)
             {
                 setdata("Wall Outer Corner ▟", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid == 5)
             {
                 setdata("Wall Outer Corner ▜", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid == 6)
             {
                 setdata("Wall Outer Corner ▙", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid == 7)
             {
                 setdata("Wall Outer Corner ▛", 4, 4);
-                sort = Sorting.Wall | Sorting.NonScalable;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable;
             }
             if (oid >= 8 && oid <= 15)
             {
                 setdata("Wall Corner (Lower)", 4, 4, true); // Corners
-                sort = Sorting.Wall | Sorting.NonScalable; ;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable; ;
             }
             if (oid >= 16 && oid <= 19)
             {
                 setdata("Wall S (Lower)",3, 4, true); // Corners
-                sort = Sorting.Wall | Sorting.NonScalable; ;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable; ;
             }
             if (oid >= 20 && oid <= 23)
             {
                 setdata("Wall S (Lower)", 4, 3, true); // Corners
-                sort = Sorting.Wall | Sorting.NonScalable; ;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable; ;
             }
             if (oid >= 24 && oid <= 27)
             {
                 setdata("Pit Edge Corner", 2, 2); // Pit Edge
-                sort = Sorting.Wall | Sorting.NonScalable; ;
+                sort = RoomObjectType.Wall | RoomObjectType.NonScalable; ;
             }
             if (oid == 0x1C)
             {
                 setdata("Fairy Pot", 4, 4);
-                sort = Sorting.Dungeons | Sorting.NonScalable; ;
+                sort = RoomObjectType.Dungeons | RoomObjectType.NonScalable; ;
             }
             else if (oid == 0x1D)
             {
                 setdata("Statue", 2, 3);
-                sort = Sorting.Dungeons | Sorting.NonScalable; ;
+                sort = RoomObjectType.Dungeons | RoomObjectType.NonScalable; ;
             }
             else if (oid == 0x1E)
             {
                 setdata("Star Tile Off", 2, 2);
-                sort = Sorting.Dungeons | Sorting.NonScalable; ;
+                sort = RoomObjectType.Dungeons | RoomObjectType.NonScalable; ;
             }
             else if (oid == 0x1F)
             {
                 setdata("Star Tile On", 2, 2);
-                sort = Sorting.Dungeons | Sorting.NonScalable; ;
+                sort = RoomObjectType.Dungeons | RoomObjectType.NonScalable; ;
             }
             else if (oid == 0x20)
             {
                 setdata("Torch Lit", 2, 2);
-                sort = Sorting.Dungeons | Sorting.NonScalable;
+                sort = RoomObjectType.Dungeons | RoomObjectType.NonScalable;
             }
             else if (oid == 0x21)
             {
                 setdata("Barrel", 2, 3);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x22)
             {
                 setdata("Weird Bed", 4, 5);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x23)
             {
                 setdata("Table", 4, 3);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x24)
             {
                 setdata("Decoration", 4, 4);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x25)
             {
                 setdata("???", 4, 4);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x26)
             {
                 setdata("???", 2, 3);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x27)
             {
                 setdata("Chair", 2, 2);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x28)
             {
                 setdata("Bed", 4, 5);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x29)
             {
                 setdata("Decoration", 4, 4);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x2A)
             {
                 setdata("Wall Painting",  4, 2);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x2B)
             {
                 setdata("???", 2, 2);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x2C)
             {
                 setdata("???",  2, 2);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x2D)
             {
                 setdata("Stairs Going Up (room)", 4, 4);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x2E)
             {
                 setdata("Stairs Going Down (room)", 4, 4);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x2F)
             {
                 setdata("Stairs Going Down2 (room)", 4, 4);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x30)
             {
                 setdata("Stairs Going Up (layer)", 4, 4, true);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x31)
             {
                 setdata("Stairs Going Up2 (layer)", 4, 4, true);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x32)
             {
                 setdata("Stairs Going Up (layer)",  4, 4);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x33)
             {
                 setdata("Stairs Going Up (layer)", 4, 4);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x34)
             {
                 setdata("Block", 2, 2);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x35)
             {
                 setdata("Water Stair",  4, 2);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x36)
             {
                 setdata("Water Stair2", 4, 2, true);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x37)
             {
                 setdata("Water Gate",  10, 4);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x38)
             {
                 setdata("Spiral Staircase Up",  4, 3);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x39)
             {
                 setdata("Spiral Staircase Down", 4, 3);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x3A)
             {
                 setdata("Spiral Staircase Up (Lower)", 4, 3);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x3B)
             {
                 setdata("Spiral Staircase Down (Lower)", 4, 3);
-                sort = Sorting.Stairs | Sorting.NonScalable;
+                sort = RoomObjectType.Stairs | RoomObjectType.NonScalable;
             }
             else if (oid == 0x3C)
             {
                 setdata("Sanctuary Wall", 4, 4);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x3D)
             {
                 setdata("???", 4, 3);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x3E)
             {
                 setdata("???",  6, 3);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x3F)
             {
                 setdata("???", 8, 7);
-                sort = Sorting.NonScalable;
+                sort = RoomObjectType.NonScalable;
             }
             else if (oid == 0x50) //special object id doesnt matter (Torches)
             {

--- a/ZeldaFullEditor/Rooms/Object_Draw/Subtype3_Draw.cs
+++ b/ZeldaFullEditor/Rooms/Object_Draw/Subtype3_Draw.cs
@@ -13,7 +13,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF)-0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF)-0x80) * 2)]);
             name = "Water Face";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -37,7 +37,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Waterfall Face";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(20, pos);//??
         }
         public override void Draw()
@@ -61,7 +61,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Waterfall Face Longer";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(28, pos);//??
         }
         public override void Draw()
@@ -85,7 +85,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(1, pos);//??
         }
         public override void Draw()
@@ -100,7 +100,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(1, pos);//??
         }
         public override void Draw()
@@ -115,7 +115,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(1, pos);//??
         }
         public override void Draw()
@@ -130,7 +130,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(1, pos);//??
         }
         public override void Draw()
@@ -144,7 +144,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(1, pos);//??
         }
         public override void Draw()
@@ -158,7 +158,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(1, pos);//??
         }
         public override void Draw()
@@ -173,7 +173,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(1, pos);//??
         }
         public override void Draw()
@@ -188,7 +188,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
             addTiles(1, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -202,7 +202,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
             addTiles(1, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -216,7 +216,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
             addTiles(1, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -231,7 +231,7 @@ namespace ZeldaFullEditor
             name = "Cell";
             addTiles(6, pos);
             addTiles(6, pos);
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             for (int i = 6;i<12;i++)
             {
                 tiles[i].mirror_x = true;
@@ -263,7 +263,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
             addTiles(1, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -277,7 +277,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
             addTiles(1, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -291,7 +291,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -316,7 +316,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "?";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -341,7 +341,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Rupee Floor";
             addTiles(4, pos);//??
-            sort = Sorting.Floors |Sorting.NonScalable; 
+            sort = RoomObjectType.Floors |RoomObjectType.NonScalable; 
         }
         public override void Draw()
         {
@@ -362,7 +362,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Telepathic Tile";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(4, pos);//??
         }
         public override void Draw()
@@ -386,7 +386,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Down Warp Door";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(12, pos);//??
         }
         public override void Draw()
@@ -410,7 +410,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Kholdstare Shell";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             
             addTiles(80, pos);//??
         }
@@ -435,7 +435,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Single Hammer Peg";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(4, pos);//??
         }
         public override void Draw()
@@ -461,7 +461,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Cell";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(6, pos);
             addTiles(6, pos);
             for (int i = 6; i < 12; i++)
@@ -497,7 +497,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Cell Lock";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(4, pos);//??
         }
         public override void Draw()
@@ -522,7 +522,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Chest";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(4, pos);//??
             this.options |= ObjectOption.Chest;
         }
@@ -547,7 +547,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Open Chest";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(4, pos);//??
         }
         public override void Draw()
@@ -570,7 +570,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Stair";
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
             allBgs = true;
             addTiles(16, pos);//??
         }
@@ -595,7 +595,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Stair";
             allBgs = true;
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
             addTiles(16, pos);//??
         }
         public override void Draw()
@@ -619,7 +619,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Stair";
             allBgs = true;
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
             addTiles(16, pos);//??
         }
         public override void Draw()
@@ -643,7 +643,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase going Up(Up)";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
         }
         public override void Draw()
         {
@@ -666,7 +666,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Down (Up)";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
         }
         public override void Draw()
         {
@@ -689,7 +689,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Up (Down)";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
         }
         public override void Draw()
         {
@@ -712,7 +712,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Down (Down)";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
         }
         public override void Draw()
         {
@@ -735,7 +735,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Pit Wall Corner";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -758,7 +758,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Pit Wall Corner";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -781,7 +781,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Pit Wall Corner";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -804,7 +804,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Pit Wall Corner";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -827,7 +827,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Up (Lower)";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
         }
         public override void Draw()
         {
@@ -849,7 +849,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Up (Lower)";
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
             addTiles(16, pos);//??
         }
         public override void Draw()
@@ -872,7 +872,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Down (Lower)";
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
             addTiles(16, pos);//??
         }
         public override void Draw()
@@ -895,7 +895,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Down (Lower)";
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
             addTiles(16, pos);//??
         }
         public override void Draw()
@@ -920,7 +920,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "LAMP";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -942,7 +942,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Staircase Going Down (Lower)";
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
             addTiles(4, pos);//??
         }
         public override void Draw()
@@ -965,7 +965,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Rock";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(16, pos);//??
         }
         public override void Draw()
@@ -993,7 +993,7 @@ namespace ZeldaFullEditor
             //harcoded position wtf ?!?
             int pos = Constants.tile_address + 0x1B4A;
             name = "Agahnim Altar?";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(84, pos);//??
         }
         public override void Draw()
@@ -1044,7 +1044,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + 0x1BF2;
             name = "Agahnim Room";
             addTiles(127, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             //6x4 (top wall) 24
             //1x5 (diago left) 5
             //4x6 (side wall) (left need to be mirrored to right) 24
@@ -1175,7 +1175,7 @@ namespace ZeldaFullEditor
             name = "Pot";
             //0x0E92; for skulls
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable | Sorting.Dungeons;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Dungeons;
         }
         public override void Draw()
         {
@@ -1198,7 +1198,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "??";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1221,7 +1221,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Big Chest";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable | Sorting.Dungeons;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Dungeons;
             options |= ObjectOption.Chest;
         }
         public override void Draw()
@@ -1246,7 +1246,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Big Chest Open";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1271,7 +1271,7 @@ namespace ZeldaFullEditor
             name = "Stairs";
             allBgs = true;
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable | Sorting.Stairs;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Stairs;
         }
         public override void Draw()
         {
@@ -1293,7 +1293,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(6, pos);//??
         }
         public override void Draw()
@@ -1317,7 +1317,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(6, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1340,7 +1340,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(18, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1363,7 +1363,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(18, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1386,7 +1386,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(18, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1409,7 +1409,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(18, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1432,7 +1432,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1465,7 +1465,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1498,7 +1498,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1522,7 +1522,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1546,7 +1546,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1569,7 +1569,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1592,7 +1592,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1615,7 +1615,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1638,7 +1638,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1661,7 +1661,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1684,7 +1684,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1707,7 +1707,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1730,7 +1730,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1753,7 +1753,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1777,7 +1777,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Bomb Floor";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1805,7 +1805,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Fake Bomb Floor";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1829,7 +1829,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1854,7 +1854,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Warp Tile";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1878,7 +1878,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1902,7 +1902,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(48, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1927,7 +1927,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(18, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1956,7 +1956,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -1981,7 +1981,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Inactive Warp";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2006,7 +2006,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Floor Switch";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2031,7 +2031,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2056,7 +2056,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Single Blue Peg";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2081,7 +2081,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Single Red Peg";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2106,7 +2106,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2130,7 +2130,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(9, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2166,7 +2166,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2190,7 +2190,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2214,7 +2214,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(6, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2238,7 +2238,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2262,7 +2262,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(8, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2287,7 +2287,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(32, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2326,7 +2326,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2350,7 +2350,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(18, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2374,7 +2374,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2399,7 +2399,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2424,7 +2424,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Left Warp Door";
             addTiles(18, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2482,7 +2482,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(242, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2506,7 +2506,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2531,7 +2531,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Medusa Head";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2577,7 +2577,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Hole";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2601,7 +2601,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Top Crack Wall";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable | Sorting.Wall;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Wall;
         }
         public override void Draw()
         {
@@ -2626,7 +2626,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Bottom Crack Wall";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable | Sorting.Wall;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Wall;
         }
         public override void Draw()
         {
@@ -2650,7 +2650,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Left Crack Wall";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable | Sorting.Wall;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Wall;
         }
         public override void Draw()
         {
@@ -2674,7 +2674,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Right Crack Wall";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable | Sorting.Wall;
+            sort = RoomObjectType.NonScalable | RoomObjectType.Wall;
         }
         public override void Draw()
         {
@@ -2697,7 +2697,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Throne/ Decoration Object";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(16, pos);//??
         }
         public override void Draw()
@@ -2721,7 +2721,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(12, pos);//??
         }
         public override void Draw()
@@ -2745,7 +2745,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(12, pos);//??
         }
         public override void Draw()
@@ -2769,7 +2769,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(12, pos);//??
         }
         public override void Draw()
@@ -2793,7 +2793,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(12, pos);//??
 
         }
@@ -2818,7 +2818,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Floor Light";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(32, pos);//??
         }
         public override void Draw()
@@ -2862,7 +2862,7 @@ namespace ZeldaFullEditor
         {
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
             addTiles(64, pos);//??
         }
         public override void Draw()
@@ -2888,7 +2888,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Trinexx Shell";
             addTiles(80, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2913,7 +2913,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Bg2 Full Mask";
             addTiles(1, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
 
         public override void Draw()
@@ -2935,7 +2935,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Boss Entrance";
             addTiles(64, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
 
         public override void Draw()
@@ -2961,7 +2961,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "Minigame Chest";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -2985,7 +2985,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3009,7 +3009,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3033,7 +3033,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(24, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3049,7 +3049,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3073,7 +3073,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(16, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3097,7 +3097,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(12, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3113,7 +3113,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3137,7 +3137,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {
@@ -3161,7 +3161,7 @@ namespace ZeldaFullEditor
             int pos = Constants.tile_address + (short)((ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2) + 1] << 8) + ROM.DATA[Constants.subtype3_tiles + (((id & 0xFF) - 0x80) * 2)]);
             name = "???";
             addTiles(4, pos);//??
-            sort = Sorting.NonScalable;
+            sort = RoomObjectType.NonScalable;
         }
         public override void Draw()
         {

--- a/ZeldaFullEditor/Rooms/Room_Object.cs
+++ b/ZeldaFullEditor/Rooms/Room_Object.cs
@@ -39,7 +39,7 @@ namespace ZeldaFullEditor
         public bool specialDraw = false;
         public bool selected = false;
         public bool redraw = false;
-        public Sorting sort = Sorting.All;
+        public RoomObjectType sort = RoomObjectType.All;
         public bool preview = false;
         public int previewId = 0;
         public Room_Object(short id, byte x, byte y, byte size, byte layer = 0)
@@ -198,7 +198,7 @@ namespace ZeldaFullEditor
     }
 
     [Flags]
-    public enum Sorting
+    public enum RoomObjectType
     {
         All = 0, Wall = 1, Horizontal = 2, Vertical = 4, NonScalable = 8, Dungeons = 16,Floors = 32, Stairs = 64
     }


### PR DESCRIPTION
The enum name `Sorting` did not best describe itself with its name. This
enum defines a room object's "type", so the name `RoomObjectType` is a
better choice.