### PR TITLE
Rename Form1 to DungeonMain

### DIFF
--- a/ZeldaFullEditor/Gui/DungeonMain.Designer.cs
+++ b/ZeldaFullEditor/Gui/DungeonMain.Designer.cs
@@ -1,6 +1,6 @@
 ﻿namespace ZeldaFullEditor
 {
-    partial class Form1
+    partial class DungeonMain
     {
         /// <summary>
         /// Required designer variable.
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DungeonMain));
             System.Windows.Forms.TreeNode treeNode1 = new System.Windows.Forms.TreeNode("Entrances");
             System.Windows.Forms.TreeNode treeNode2 = new System.Windows.Forms.TreeNode("Starting Entrances");
             System.Windows.Forms.TreeNode treeNode3 = new System.Windows.Forms.TreeNode("Current Room / Map");

--- a/ZeldaFullEditor/Gui/DungeonMain.cs
+++ b/ZeldaFullEditor/Gui/DungeonMain.cs
@@ -21,9 +21,9 @@ using ZeldaFullEditor.Gui;
 namespace ZeldaFullEditor
 {
 
-    public partial class Form1 : Form
+    public partial class DungeonMain : Form
     {
-        public Form1()
+        public DungeonMain()
         {
             InitializeComponent();
 

--- a/ZeldaFullEditor/Program.cs
+++ b/ZeldaFullEditor/Program.cs
@@ -16,7 +16,7 @@ namespace ZeldaFullEditor
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            Application.Run(new DungeonMain());
         }
     }
 }

--- a/ZeldaFullEditor/RoomLayout.cs
+++ b/ZeldaFullEditor/RoomLayout.cs
@@ -13,7 +13,7 @@ namespace ZeldaFullEditor
 {
     public partial class RoomLayout : Form
     {
-        public RoomLayout(Form1 f)
+        public RoomLayout(DungeonMain f)
         {
             InitializeComponent();
             /*foreach (string s in Directory.EnumerateDirectories("Layout\\"))

--- a/ZeldaFullEditor/SceneBase.cs
+++ b/ZeldaFullEditor/SceneBase.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 using ZeldaFullEditor.Properties;
 using Microsoft.VisualBasic;
 using System.IO.Compression;
-using static ZeldaFullEditor.Form1;
+using static ZeldaFullEditor.DungeonMain;
 using System.Drawing.Imaging;
 using System.Drawing.Drawing2D;
 
@@ -40,7 +40,7 @@ namespace ZeldaFullEditor
         public bool showLayer2 = true;
         public bool showGrid = false;
         public bool showSpriteText = false;
-        public Form1 mainForm;
+        public DungeonMain mainForm;
         public bool canSelectUnselectedBG = true;
         public bool isDungeon = true;
         //public List<Room> undoRooms = new List<Room>();

--- a/ZeldaFullEditor/SceneOW.cs
+++ b/ZeldaFullEditor/SceneOW.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 using ZeldaFullEditor.Properties;
 using Microsoft.VisualBasic;
 using System.IO.Compression;
-using static ZeldaFullEditor.Form1;
+using static ZeldaFullEditor.DungeonMain;
 using System.Drawing.Imaging;
 using System.Drawing.Drawing2D;
 using System.Runtime.InteropServices;
@@ -61,7 +61,7 @@ namespace ZeldaFullEditor
         public bool showSprites = true;
         public bool hideText = false;
         //int selectedMode = 0;
-        public SceneOW(Form1 f)
+        public SceneOW(DungeonMain f)
         {
             //graphics = Graphics.FromImage(scene_bitmap);
             //this.Image = new Bitmap(4096, 4096);

--- a/ZeldaFullEditor/SceneUW.cs
+++ b/ZeldaFullEditor/SceneUW.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 using ZeldaFullEditor.Properties;
 using Microsoft.VisualBasic;
 using System.IO.Compression;
-using static ZeldaFullEditor.Form1;
+using static ZeldaFullEditor.DungeonMain;
 using System.Drawing.Imaging;
 using System.Drawing.Drawing2D;
 
@@ -20,7 +20,7 @@ namespace ZeldaFullEditor
     public class SceneUW : Scene
     {
 
-        public SceneUW(Form1 f)
+        public SceneUW(DungeonMain f)
         {
             //graphics = Graphics.FromImage(scene_bitmap);
             
@@ -2467,7 +2467,7 @@ namespace ZeldaFullEditor
 
         }
 
-        public void updateRoomInfos(Form1 mainForm)
+        public void updateRoomInfos(DungeonMain mainForm)
         {
             mainForm.propertiesChangedFromForm = true;
             mainForm.roomProperty_bg2.SelectedIndex = (int)room.Bg2;


### PR DESCRIPTION
Classes should be named after the file that contains them. Further,
DungeonMain is a less ambiguous name than Form1.